### PR TITLE
h2サーバモードをtcpからfileに変更。

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <!-- gsp-dba-maven-pluginが使用するデータベース設定 -->
     <nablarch.db.jdbcDriver>org.h2.Driver</nablarch.db.jdbcDriver>
-    <nablarch.db.url>jdbc:h2:tcp://localhost:9092/./db/tiscon4</nablarch.db.url>
+    <nablarch.db.url>jdbc:h2:file:./db/tiscon4</nablarch.db.url>
     <nablarch.db.adminUser>sa</nablarch.db.adminUser>
     <nablarch.db.user>tiscon4</nablarch.db.user>
     <nablarch.db.password>p@ssw0rd</nablarch.db.password>

--- a/src/main/resources/env.config
+++ b/src/main/resources/env.config
@@ -6,7 +6,7 @@ nablarch.connectionFactory.jndiResourceName=
 nablarch.db.jdbcDriver=org.h2.Driver
 
 # JDBC接続URL(DataSourceを直接使用する際の項目)
-nablarch.db.url=jdbc:h2:tcp://localhost:9092/./db/tiscon4
+nablarch.db.url=jdbc:h2:file:./db/tiscon4;AUTO_SERVER=true
 
 # DB接続ユーザ名(DataSourceを直接使用する際の項目)
 nablarch.db.user=tiscon4


### PR DESCRIPTION
h2サーバを起動させる手順を減らすため。
AUTO_SERVERオプションを有効にしているので、Webアプリケーション起動時でもH2コンソールが使用可能。

http://www.h2database.com/html/features.html#auto_mixed_mode
http://siosio.hatenablog.com/entry/2016/12/02/081517